### PR TITLE
Update upload artifact action to v4

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -64,7 +64,7 @@ jobs:
         buildozer -v android debug
     
     - name: Upload APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: procedural-breakout-apk
         path: android_build/bin/*.apk


### PR DESCRIPTION
Update `actions/upload-artifact` to v4 to resolve workflow failures caused by the deprecated v3.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8bbbb21-fdea-4f62-b36a-3a5bd80c6456">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8bbbb21-fdea-4f62-b36a-3a5bd80c6456">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

